### PR TITLE
Evaluating code from the sandbox

### DIFF
--- a/sandbox.el
+++ b/sandbox.el
@@ -184,6 +184,22 @@ redefunned, return true. "
                             '(sit-for 0)
                             body)))))))))
 
+(defun sandbox-def-unbound-fns (expr &optional prefix)
+  "Defines unbound PREFIX functions in EXPR."
+  (cond ((listp expr)
+         (let* ((prefix (or prefix sandbox-prefix))
+                (function-name (first expr))
+                (function-name-str (symbol-name (first expr)))
+                (remaining-expr (rest expr))
+                (orig-function-name (intern (substring function-name-str (length prefix)))))
+           (if (and (not (fboundp function-name))
+                    (string-match (format "^%s" prefix) function-name-str)
+                    (fboundp orig-function-name))
+               (fset function-name (symbol-function orig-function-name)))
+           (unless (null (rest expr))
+             (mapcar (lambda (expr) (sandbox-def-unbound-fns expr))
+                     (rest expr)))))))
+
 (defun sandbox-eval (form &optional prefix)
   (unless (or (stringp prefix) (eq nil prefix))
     (error "Prefix should be a string"))

--- a/sandbox.el
+++ b/sandbox.el
@@ -128,7 +128,7 @@ We WON'T do this by default since this could lead to exploits if you
 
 (defun sandbox-constant-object-p (object)
   "If the object is a symbol like nil or t, a symbol that cannot be
-redefunned, return true. "
+redefunned, return true."
   (or (member object (list nil t))
       (keywordp object)))
 
@@ -191,7 +191,8 @@ redefunned, return true. "
                 (function-name (first expr))
                 (function-name-str (symbol-name (first expr)))
                 (remaining-expr (rest expr))
-                (orig-function-name (intern (substring function-name-str (length prefix)))))
+                (orig-function-name (if (> (length function-name-str) (length prefix))
+                                        (intern (substring function-name-str (length prefix))))))
            (if (and (not (fboundp function-name))
                     (string-match (format "^%s" prefix) function-name-str)
                     (fboundp orig-function-name))
@@ -199,6 +200,11 @@ redefunned, return true. "
            (unless (null (rest expr))
              (mapcar (lambda (expr) (sandbox-def-unbound-fns expr))
                      (rest expr)))))))
+
+(defmacro sandbox-define-unbound-functions (sexpr)
+  "Define unbound functions in SEXPR, which is a prefixed sandboxed string."
+  (unless (equal 'quote (first sexpr))
+    `(cons 'quote (sandbox-def-unbound-fns ',sexpr))))
 
 (defun sandbox-eval (form &optional prefix)
   (unless (or (stringp prefix) (eq nil prefix))

--- a/spec/sandbox-spec.el
+++ b/spec/sandbox-spec.el
@@ -60,13 +60,29 @@
      (let ((i 0))
        (sandbox-while t (incf i))))))
 
+(describe "sandbox-def-unbound-fns"
+  (it "defines sandboxed functions if they aren't defined yet"
+    (progn
+      (fmakunbound 'emacs-sandbox-progn)
+      (fmakunbound 'emacs-sandbox-defun)
+      (fmakunbound 'emacs-sandbox-+)
+      (sandbox-def-unbound-fns
+       '(emacs-sandbox-progn
+         (emacs-sandbox-defun emacs-sandbox-testsum (emacs-sandbox-one emacs-sandbox-two) (emacs-sandbox-+ emacs-sandbox-one emacs-sandbox-two))
+         (emacs-sandbox-testsum 1 2)))
+      (should (eq t (and (fboundp 'emacs-sandbox-progn)
+                         (fboundp 'emacs-sandbox-defun)
+                         (fboundp 'emacs-sandbox-+)))))))
+
 (describe "sandbox-eval"
   (it "will eval defuns in a different namespace"
-    ;; todo: make a test scenario that will actually pass
-    (should (eq 3
-                (sandbox-eval
-                 '(progn (defun testfn (one two) (+ one two))
-                         (testfn 1 2)))))))
+      (should (eq 3
+                  (progn
+                    (let ((expression '(progn
+                                         (defun testfn (one two) (+ one two))
+                                         (testfn 1 2))))
+                      (sandbox-def-unbound-fns (sandbox expression))
+                      (sandbox-eval expression)))))))
 
 ;; actual spec tests
 (describe "sandbox"

--- a/spec/sandbox-spec.el
+++ b/spec/sandbox-spec.el
@@ -72,6 +72,18 @@
          (emacs-sandbox-testsum 1 2)))
       (should (eq t (and (fboundp 'emacs-sandbox-progn)
                          (fboundp 'emacs-sandbox-defun)
+                         (fboundp 'emacs-sandbox-+))))))
+  (it "also has a macro"
+    (progn
+      (fmakunbound 'emacs-sandbox-progn)
+      (fmakunbound 'emacs-sandbox-defun)
+      (fmakunbound 'emacs-sandbox-+)
+      (sandbox-define-unbound-functions
+            (emacs-sandbox-progn
+             (emacs-sandbox-defun emacs-sandbox-testsum (emacs-sandbox-one emacs-sandbox-two) (emacs-sandbox-+ emacs-sandbox-one emacs-sandbox-two))
+             (emacs-sandbox-testsum 1 2)))
+      (should (eq t (and (fboundp 'emacs-sandbox-progn)
+                         (fboundp 'emacs-sandbox-defun)
                          (fboundp 'emacs-sandbox-+)))))))
 
 (describe "sandbox-eval"


### PR DESCRIPTION
This function should eval forms coming out of the sandbox by getting their original definitions and binding them to the sandboxed code. Note that if there is a previous definition for a sandbox symbol, it will use that instead (so it won't redefine some functions that should be protected, like defun and while).
