### PR TITLE
Don't use privileged URLs for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/el-spec"]
 	path = vendor/el-spec
-	url = git@github.com:joelmccracken/el-spec.git
+	url = https://github.com/joelmccracken/el-spec.git
 [submodule "vendor/test-double"]
 	path = vendor/test-double
-	url = git@github.com:joelmccracken/test-double.git
+	url = https://github.com/joelmccracken/test-double.git


### PR DESCRIPTION
This commit allows people who aren't you to check out your repo's submodules.

See end of https://s3.amazonaws.com/archive.travis-ci.org/jobs/100565404/log.txt for an example of the problem this fixes.